### PR TITLE
Allow hot-loading of emojis

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -205,6 +205,10 @@ bukkit {
             description = 'Reloads all tutorials'
             usage = '/reloadtutorials'
         }
+        reloademojis {
+            description = 'Reloads all emojis'
+            usage = '/reloademojis'
+        }
         leavetutorial {
             description = 'Exit the tutorial you are currently in'
             usage = '/leavetutorial'
@@ -314,6 +318,9 @@ bukkit {
         }
         'parallelutils.reloadtutorials' {
             description = 'Gives access to reloadtutorials command'
+        }
+        'parallelutils.reloademojis' {
+            description = 'Gives access to reloademojis command'
         }
         'parallelutils.tutorialinfo' {
             description = 'Gives access to tutorialinfo command'

--- a/modules/src/main/java/parallelmc/parallelutils/modules/parallelchat/ParallelChat.java
+++ b/modules/src/main/java/parallelmc/parallelutils/modules/parallelchat/ParallelChat.java
@@ -256,6 +256,7 @@ public class ParallelChat extends ParallelModule {
         puPlugin.getCommand("colors").setExecutor(new ParallelColors());
         puPlugin.getCommand("formats").setExecutor(new ParallelFormats());
         puPlugin.getCommand("dnd").setExecutor(new ParallelDoNotDisturb());
+        puPlugin.getCommand("reloademojis").setExecutor(new ParallelReloadEmojis());
 
         this.chatroomCommands = new ChatroomCommands();
         addChatRoomCommand("create", new ParallelCreateChatroom());

--- a/modules/src/main/java/parallelmc/parallelutils/modules/parallelchat/commands/ParallelReloadEmojis.java
+++ b/modules/src/main/java/parallelmc/parallelutils/modules/parallelchat/commands/ParallelReloadEmojis.java
@@ -1,0 +1,34 @@
+package parallelmc.parallelutils.modules.parallelchat.commands;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import parallelmc.parallelutils.ParallelUtils;
+import parallelmc.parallelutils.modules.parallelchat.ParallelChat;
+
+import java.util.logging.Level;
+
+public class ParallelReloadEmojis implements CommandExecutor {
+    @Override
+    public boolean onCommand(@NotNull CommandSender commandSender, @NotNull Command command, @NotNull String label, String[] args) {
+        if (commandSender.hasPermission("parallelutils.reloademojis")) {
+            if (ParallelChat.get().emojiManager.loadEmojis()) {
+                int emojis = ParallelChat.get().emojiManager.getEmojis().size();
+                if (commandSender instanceof Player player) {
+                    ParallelChat.sendParallelMessageTo(player, "Loaded " + emojis + " emojis.");
+                }
+                else {
+                    ParallelUtils.log(Level.WARNING, "Loaded " + emojis + " emojis.");
+                }
+            }
+            else {
+                if (commandSender instanceof Player player) {
+                    ParallelChat.sendParallelMessageTo(player, "Failed to load emojis! Check the console for an error.");
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/modules/src/main/java/parallelmc/parallelutils/modules/parallelchat/commands/ParallelReloadEmojis.java
+++ b/modules/src/main/java/parallelmc/parallelutils/modules/parallelchat/commands/ParallelReloadEmojis.java
@@ -7,7 +7,9 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import parallelmc.parallelutils.ParallelUtils;
 import parallelmc.parallelutils.modules.parallelchat.ParallelChat;
+import parallelmc.parallelutils.modules.parallelchat.emojis.Emoji;
 
+import java.util.HashMap;
 import java.util.logging.Level;
 
 public class ParallelReloadEmojis implements CommandExecutor {
@@ -15,12 +17,17 @@ public class ParallelReloadEmojis implements CommandExecutor {
     public boolean onCommand(@NotNull CommandSender commandSender, @NotNull Command command, @NotNull String label, String[] args) {
         if (commandSender.hasPermission("parallelutils.reloademojis")) {
             if (ParallelChat.get().emojiManager.loadEmojis()) {
-                int emojis = ParallelChat.get().emojiManager.getEmojis().size();
-                if (commandSender instanceof Player player) {
-                    ParallelChat.sendParallelMessageTo(player, "Loaded " + emojis + " emojis.");
+                HashMap<String, Emoji> e = ParallelChat.get().emojiManager.getEmojis();
+                if (e != null) {
+                    int emojis = e.size();
+                    if (commandSender instanceof Player player) {
+                        ParallelChat.sendParallelMessageTo(player, "Loaded " + emojis + " emojis.");
+                    } else {
+                        ParallelUtils.log(Level.WARNING, "Loaded " + emojis + " emojis.");
+                    }
                 }
                 else {
-                    ParallelUtils.log(Level.WARNING, "Loaded " + emojis + " emojis.");
+                    ParallelUtils.log(Level.SEVERE, "getEmojis() returned null. This shouldn't happen!");
                 }
             }
             else {

--- a/modules/src/main/java/parallelmc/parallelutils/modules/parallelchat/emojis/EmojiManager.java
+++ b/modules/src/main/java/parallelmc/parallelutils/modules/parallelchat/emojis/EmojiManager.java
@@ -28,6 +28,14 @@ import java.util.logging.Level;
 public class EmojiManager {
     private final HashMap<String, Emoji> emojis = new HashMap<>();
     public EmojiManager() {
+        loadEmojis();
+    }
+
+    /***
+     * Loads emojis from their config file into memory
+     * @return If the emojis were successfully loaded
+     */
+    public boolean loadEmojis() {
         File emoteFile = new File(ParallelChat.get().getPlugin().getDataFolder(), "emojis.yml");
         FileConfiguration emoteConfig = new YamlConfiguration();
         try {
@@ -37,10 +45,10 @@ public class EmojiManager {
             emoteConfig.load(emoteFile);
         } catch (IOException e) {
             ParallelUtils.log(Level.SEVERE, "Failed to create or read emojis.yml\n" + e);
-            return;
+            return false;
         } catch (Exception e) {
             ParallelUtils.log(Level.SEVERE, "Failed to load emojis.yml\n" + e);
-            return;
+            return false;
         }
         for (String key : emoteConfig.getKeys(false)) {
             String id = emoteConfig.getString("id");
@@ -52,6 +60,7 @@ public class EmojiManager {
             emojis.put(id, new Emoji(key, id, replacement));
         }
         ParallelUtils.log(Level.WARNING, "Loaded " + emojis.size() + " emojis.");
+        return true;
     }
 
     public HashMap<String, Emoji> getEmojis() { return emojis; }


### PR DESCRIPTION
This pr would allow emojis to be hot-reloaded via a command. A player would need the `parallelutils.reloademojis` permission to run the command. While the resource pack would still need to be updated for these to work it would allow emojis to be swapped out a lot easier without having to restart the server.