### PR TITLE
ChestShop Fixes (diamond bug + dupe)

### DIFF
--- a/modules/src/main/java/parallelmc/parallelutils/modules/chestshops/events/OnShopInteract.java
+++ b/modules/src/main/java/parallelmc/parallelutils/modules/chestshops/events/OnShopInteract.java
@@ -2,7 +2,9 @@ package parallelmc.parallelutils.modules.chestshops.events;
 
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -25,7 +27,13 @@ public class OnShopInteract implements Listener {
         Player player = (Player)event.getWhoClicked();
         ShopperData data = ChestShops.get().getShoppingData(player);
         Inventory inv = event.getClickedInventory();
-        if (data != null && data.fakeInv().equals(inv) && event.getCurrentItem() != null) {
+        if (data != null && data.fakeInv().equals(event.getInventory()) && event.getCurrentItem() != null) {
+            event.setCancelled(true);
+            // if the clicked inventory is not the ChestShop inventory (the player's inventory usually)
+            // then do nothing
+            if (!data.fakeInv().equals(event.getClickedInventory())) {
+                return;
+            }
             if (!inv.containsAtLeast(event.getCurrentItem(), data.shop().sellAmt())) {
                 ParallelChat.sendParallelMessageTo(player, "Shop is out of stock!");
                 player.closeInventory();
@@ -95,7 +103,12 @@ public class OnShopInteract implements Listener {
                 name = give.getItemMeta().displayName();
             }
             ParallelChat.sendParallelMessageTo(player, Component.text("You bought " + data.shop().sellAmt() + "x ", NamedTextColor.GREEN).append(name));
-            event.setCancelled(true);
+            OfflinePlayer owner = Bukkit.getOfflinePlayer(data.shop().owner());
+            if (owner.isOnline()) {
+                ParallelChat.sendParallelMessageTo(owner.getPlayer(), Component.text(player.getName() + " bought " + data.shop().sellAmt() + "x ", NamedTextColor.GREEN)
+                        .append(name)
+                        .append(Component.text(" from your ChestShop!", NamedTextColor.GREEN)));
+            }
         }
     }
 

--- a/modules/src/main/java/parallelmc/parallelutils/modules/chestshops/events/OnSignText.java
+++ b/modules/src/main/java/parallelmc/parallelutils/modules/chestshops/events/OnSignText.java
@@ -74,6 +74,11 @@ public class OnSignText implements Listener {
                         ParallelChat.sendParallelMessageTo(player, "Please place the item to sell in the first slot of the chest.");
                         return;
                     }
+                    if (inv.firstEmpty() == -1) {
+                        event.setCancelled(true);
+                        ParallelChat.sendParallelMessageTo(player, "There must be at least one empty slot in the chest.");
+                        return;
+                    }
                     if (sell.getType() == Material.DIAMOND || sell.getType() == Material.DIAMOND_BLOCK) {
                         event.setCancelled(true);
                         ParallelChat.sendParallelMessageTo(player, "You cannot sell diamonds!");

--- a/modules/src/main/java/parallelmc/parallelutils/modules/paralleltutorial/ParallelTutorial.java
+++ b/modules/src/main/java/parallelmc/parallelutils/modules/paralleltutorial/ParallelTutorial.java
@@ -484,11 +484,7 @@ public class ParallelTutorial extends ParallelModule {
     private void forceSpectate(Player player, int entityId) {
         PacketContainer packet = protManager.createPacket(PacketType.Play.Server.CAMERA);
         packet.getIntegers().write(0, entityId);
-        try {
-            protManager.sendServerPacket(player, packet);
-        } catch (InvocationTargetException e) {
-            e.printStackTrace();
-        }
+        protManager.sendServerPacket(player, packet);
     }
 
     private Vector lookAt(ArmorStand stand, Vector block) {


### PR DESCRIPTION
This PR contains important fixes for ChestShops, mainly pertaining to an existing dupe/dupes and also the enforcement of a single empty slot in a ChestShop in order to fix diamonds not being given to the shop owner in certain cases. The PR also removes the try/catch from sendServerPacket() as apparently that function does not throw that exception anymore (I could not compile without removing this try/catch).

This PR also adds in functionality of notifying the shop owner whenever someone purchases and item from their shop.