### PR TITLE
World specific resource packs

### DIFF
--- a/modules/src/main/java/parallelmc/parallelutils/modules/parallelresources/Config.java
+++ b/modules/src/main/java/parallelmc/parallelutils/modules/parallelresources/Config.java
@@ -1,0 +1,18 @@
+package parallelmc.parallelutils.modules.parallelresources;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Config implements parallelmc.parallelutils.Config {
+	@Override
+	public @NotNull List<String> getHardDepends() {
+		return new ArrayList<>();
+	}
+
+	@Override
+	public @NotNull List<String> getSoftDepends() {
+		return new ArrayList<>();
+	}
+}

--- a/modules/src/main/java/parallelmc/parallelutils/modules/parallelresources/ParallelResources.java
+++ b/modules/src/main/java/parallelmc/parallelutils/modules/parallelresources/ParallelResources.java
@@ -19,6 +19,9 @@ public class ParallelResources extends ParallelModule {
 
 	public static ParallelUtils puPlugin;
 
+	private ResourceServer server;
+	private Thread serverThread;
+
 	public ParallelResources(ParallelClassLoader classLoader, List<String> dependents) {
 		super(classLoader, dependents);
 	}
@@ -40,7 +43,7 @@ public class ParallelResources extends ParallelModule {
 			return;
 		}
 
-		ResourceServer server = new ResourceServer();
+		server = new ResourceServer();
 
 		try {
 			// Create resources directory if it does not exist
@@ -55,7 +58,7 @@ public class ParallelResources extends ParallelModule {
 			ParallelUtils.log(Level.SEVERE, "IOException while loading ParallelResources! Quitting...");
 		}
 
-		Thread serverThread = new Thread(server);
+		serverThread = new Thread(server);
 		serverThread.start();
 	}
 
@@ -71,7 +74,10 @@ public class ParallelResources extends ParallelModule {
 
 	@Override
 	public void onUnload() {
-
+		serverThread.interrupt();
+		serverThread = null;
+		server.destruct();
+		server = null;
 	}
 
 	@Override

--- a/modules/src/main/java/parallelmc/parallelutils/modules/parallelresources/ParallelResources.java
+++ b/modules/src/main/java/parallelmc/parallelutils/modules/parallelresources/ParallelResources.java
@@ -1,0 +1,78 @@
+package parallelmc.parallelutils.modules.parallelresources;
+
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.PluginManager;
+import org.jetbrains.annotations.NotNull;
+import parallelmc.parallelutils.Constants;
+import parallelmc.parallelutils.ParallelClassLoader;
+import parallelmc.parallelutils.ParallelModule;
+import parallelmc.parallelutils.ParallelUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.logging.Level;
+
+public class ParallelResources extends ParallelModule {
+
+	public static ParallelUtils puPlugin;
+
+	public ParallelResources(ParallelClassLoader classLoader, List<String> dependents) {
+		super(classLoader, dependents);
+	}
+
+	@Override
+	public void onLoad() {
+		PluginManager manager = Bukkit.getPluginManager();
+		Plugin plugin = manager.getPlugin(Constants.PLUGIN_NAME);
+
+		if (plugin == null) {
+			ParallelUtils.log(Level.SEVERE, "Unable to enable ParallelResources. Plugin " + Constants.PLUGIN_NAME + " does not exist!");
+			return;
+		}
+
+		puPlugin = (ParallelUtils) plugin;
+
+		if (!puPlugin.registerModule(this)) {
+			ParallelUtils.log(Level.SEVERE, "Unable to register module ParallelResources! Module may already be registered. Quitting...");
+			return;
+		}
+
+		try {
+			// Create resources directory if it does not exist
+			File resourcesDir = new File(puPlugin.getDataFolder(), "resources/");
+
+			if (!resourcesDir.exists()) {
+				Files.createDirectory(resourcesDir.toPath());
+			}
+
+
+
+		} catch (IOException e) {
+			e.printStackTrace();
+			ParallelUtils.log(Level.SEVERE, "IOException while loading ParallelResources! Quitting...");
+		}
+	}
+
+	@Override
+	public void onEnable() {
+
+	}
+
+	@Override
+	public void onDisable() {
+
+	}
+
+	@Override
+	public void onUnload() {
+
+	}
+
+	@Override
+	public @NotNull String getName() {
+		return "ParallelResources";
+	}
+}

--- a/modules/src/main/java/parallelmc/parallelutils/modules/parallelresources/ParallelResources.java
+++ b/modules/src/main/java/parallelmc/parallelutils/modules/parallelresources/ParallelResources.java
@@ -1,9 +1,12 @@
 package parallelmc.parallelutils.modules.parallelresources;
 
 import org.bukkit.Bukkit;
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import parallelmc.parallelutils.Constants;
 import parallelmc.parallelutils.ParallelClassLoader;
 import parallelmc.parallelutils.ParallelModule;
@@ -19,8 +22,11 @@ public class ParallelResources extends ParallelModule {
 
 	public static ParallelUtils puPlugin;
 
+
 	private ResourceServer server;
 	private Thread serverThread;
+
+	private YamlConfiguration resourcesConfig = new YamlConfiguration();
 
 	public ParallelResources(ParallelClassLoader classLoader, List<String> dependents) {
 		super(classLoader, dependents);
@@ -43,19 +49,53 @@ public class ParallelResources extends ParallelModule {
 			return;
 		}
 
-		server = new ResourceServer();
+		// Read config to get base_url, port
 
 		try {
 			// Create resources directory if it does not exist
 			File resourcesDir = new File(puPlugin.getDataFolder(), "resources/");
-
 			if (!resourcesDir.exists()) {
 				Files.createDirectory(resourcesDir.toPath());
 			}
 
+			File resourcesFile = new File(resourcesDir, "parallelresources.yml");
+
+			// Set defaults
+			if (!resourcesFile.exists()) {
+				resourcesConfig.set("domain", "resources.parallelmc.org");
+				resourcesConfig.set("port", 4444);
+				resourcesConfig.set("https", false);
+				resourcesConfig.set("https_keystore", null);
+				resourcesConfig.set("https_keystore_pass", null);
+				resourcesConfig.save(resourcesFile);
+			} else {
+				resourcesConfig.load(resourcesFile);
+			}
+
+			String domain = resourcesConfig.getString("domain", "resources.parallelmc.org");
+
+			// Initialize server
+			int port = resourcesConfig.getInt("port", 4444);
+			boolean https = resourcesConfig.getBoolean("https", false);
+			String keystore = resourcesConfig.getString("https_keystore", null);
+			String keystore_pass = resourcesConfig.getString("https_keystore_pass", null);
+
+			server = new ResourceServer(port, https, keystore != null ? new File(resourcesDir, keystore) : null, keystore_pass);
+
+			String https_head = https ? "https://" : "http://";
+
+			String base_url = https_head + domain + ":" + port + "/";
+
+			// Load resources
+			
+
+
+
 		} catch (IOException e) {
 			e.printStackTrace();
 			ParallelUtils.log(Level.SEVERE, "IOException while loading ParallelResources! Quitting...");
+		} catch (InvalidConfigurationException e) {
+			throw new RuntimeException(e);
 		}
 
 		serverThread = new Thread(server);
@@ -78,6 +118,7 @@ public class ParallelResources extends ParallelModule {
 		serverThread = null;
 		server.destruct();
 		server = null;
+		resourcesConfig = null;
 	}
 
 	@Override

--- a/modules/src/main/java/parallelmc/parallelutils/modules/parallelresources/ParallelResources.java
+++ b/modules/src/main/java/parallelmc/parallelutils/modules/parallelresources/ParallelResources.java
@@ -40,6 +40,8 @@ public class ParallelResources extends ParallelModule {
 			return;
 		}
 
+		ResourceServer server = new ResourceServer();
+
 		try {
 			// Create resources directory if it does not exist
 			File resourcesDir = new File(puPlugin.getDataFolder(), "resources/");
@@ -48,12 +50,13 @@ public class ParallelResources extends ParallelModule {
 				Files.createDirectory(resourcesDir.toPath());
 			}
 
-
-
 		} catch (IOException e) {
 			e.printStackTrace();
 			ParallelUtils.log(Level.SEVERE, "IOException while loading ParallelResources! Quitting...");
 		}
+
+		Thread serverThread = new Thread(server);
+		serverThread.start();
 	}
 
 	@Override

--- a/modules/src/main/java/parallelmc/parallelutils/modules/parallelresources/ParallelResources.java
+++ b/modules/src/main/java/parallelmc/parallelutils/modules/parallelresources/ParallelResources.java
@@ -185,9 +185,8 @@ public class ParallelResources extends ParallelModule {
 
 			if (!squashOut.exists()) {
 				Files.createDirectory(squashOut.toPath());
-			} else {
-				purgeDirectory(squashOut);
 			}
+			// Don't delete files so packsquash can cache
 
 			if (!modOut.exists()) {
 				Files.createDirectory(modOut.toPath());
@@ -459,7 +458,7 @@ public class ParallelResources extends ParallelModule {
 		}
 
 		try {
-			ParallelUtils.log(Level.INFO, "- PackSquash finished with code " + packSquashProcess.waitFor());
+			ParallelUtils.log(Level.INFO, "- PackSquash finished squashing " + infile.getName() + " with code " + packSquashProcess.waitFor());
 		} catch (final InterruptedException exc) {
 			ParallelUtils.log(Level.WARNING, "- Thread interrupted while waiting for PackSquash to finish!");
 			exc.printStackTrace();

--- a/modules/src/main/java/parallelmc/parallelutils/modules/parallelresources/ResourceServer.java
+++ b/modules/src/main/java/parallelmc/parallelutils/modules/parallelresources/ResourceServer.java
@@ -1,4 +1,97 @@
 package parallelmc.parallelutils.modules.parallelresources;
 
-public class ResourceServer {
+import com.sun.net.httpserver.HttpContext;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import parallelmc.parallelutils.ParallelUtils;
+
+import java.io.*;
+import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.logging.Level;
+
+public class ResourceServer implements Runnable{
+
+	private HashMap<String, File> resourceMap = new HashMap<>();
+
+	private HttpServer server;
+
+	private final int port;
+
+	public ResourceServer(int port) {
+		this.port = port;
+	}
+
+	public ResourceServer() {
+		this(8005);
+	}
+
+	public void destruct() {
+		server.stop(0);
+
+		server = null;
+		resourceMap = null;
+	}
+
+	public boolean addResource(String world, File pack) {
+
+		if (resourceMap.containsKey(world)) {
+			return false;
+		}
+
+		resourceMap.put(world, pack);
+
+		server.createContext("/" + pack.getName(), new ServerHandler(resourceMap));
+
+		return true;
+	}
+
+	public void updateResource(String world, File pack) {
+		resourceMap.put(world, pack);
+
+		server.createContext("/" + pack.getName(), new ServerHandler(resourceMap));
+	}
+
+	@Override
+	public void run() {
+		ParallelUtils.log(Level.INFO, "Starting resources server...");
+		try {
+			server = HttpServer.create(new InetSocketAddress(port), 0);
+			server.setExecutor(null);
+			server.start();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		ParallelUtils.log(Level.WARNING, "Resources Server Started");
+	}
+
+	static class ServerHandler implements HttpHandler {
+
+		private final HashMap<String, File> resourceMap;
+
+		public ServerHandler(HashMap<String, File> resourceMap) {
+			this.resourceMap = resourceMap;
+		}
+
+
+		@Override
+		public void handle(HttpExchange t) throws IOException {
+			String path = t.getHttpContext().getPath();
+
+			File resource = resourceMap.get(path);
+			Path pathObj = resource.toPath();
+
+			long resourceLen = Files.size(pathObj);
+
+			t.sendResponseHeaders(200, resourceLen);
+
+			try (OutputStream os = t.getResponseBody()) {
+				Files.copy(pathObj, os);
+				os.flush();
+			}
+		}
+	}
 }

--- a/modules/src/main/java/parallelmc/parallelutils/modules/parallelresources/ResourceServer.java
+++ b/modules/src/main/java/parallelmc/parallelutils/modules/parallelresources/ResourceServer.java
@@ -146,6 +146,11 @@ public class ResourceServer implements Runnable{
 			String path = t.getHttpContext().getPath();
 
 			File resource = resourceMap.get(path);
+
+			if (resource == null) {
+				resource = resourceMap.get("base");
+			}
+
 			Path pathObj = resource.toPath();
 
 			long resourceLen = Files.size(pathObj);

--- a/modules/src/main/java/parallelmc/parallelutils/modules/parallelresources/ResourceServer.java
+++ b/modules/src/main/java/parallelmc/parallelutils/modules/parallelresources/ResourceServer.java
@@ -1,0 +1,4 @@
+package parallelmc.parallelutils.modules.parallelresources;
+
+public class ResourceServer {
+}

--- a/modules/src/main/java/parallelmc/parallelutils/modules/parallelresources/ResourceServer.java
+++ b/modules/src/main/java/parallelmc/parallelutils/modules/parallelresources/ResourceServer.java
@@ -148,6 +148,7 @@ public class ResourceServer implements Runnable{
 			File resource = resourceMap.get(path);
 
 			if (resource == null) {
+				ParallelUtils.log(Level.INFO, "Tried getting pack for " + path + ", but was null. Defaulting to base.");
 				resource = resourceMap.get("base");
 			}
 

--- a/modules/src/main/java/parallelmc/parallelutils/modules/parallelresources/ResourceServer.java
+++ b/modules/src/main/java/parallelmc/parallelutils/modules/parallelresources/ResourceServer.java
@@ -1,9 +1,9 @@
 package parallelmc.parallelutils.modules.parallelresources;
 
-import com.sun.net.httpserver.HttpContext;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
+import org.jetbrains.annotations.NotNull;
 import parallelmc.parallelutils.ParallelUtils;
 
 import java.io.*;
@@ -36,7 +36,7 @@ public class ResourceServer implements Runnable{
 		resourceMap = null;
 	}
 
-	public boolean addResource(String world, File pack) {
+	public boolean addResource(@NotNull String world, @NotNull File pack) {
 
 		if (resourceMap.containsKey(world)) {
 			return false;
@@ -49,7 +49,7 @@ public class ResourceServer implements Runnable{
 		return true;
 	}
 
-	public void updateResource(String world, File pack) {
+	public void updateResource(@NotNull String world, @NotNull File pack) {
 		resourceMap.put(world, pack);
 
 		server.createContext("/" + pack.getName(), new ServerHandler(resourceMap));
@@ -72,7 +72,7 @@ public class ResourceServer implements Runnable{
 
 		private final HashMap<String, File> resourceMap;
 
-		public ServerHandler(HashMap<String, File> resourceMap) {
+		public ServerHandler(@NotNull HashMap<String, File> resourceMap) {
 			this.resourceMap = resourceMap;
 		}
 

--- a/modules/src/main/java/parallelmc/parallelutils/modules/parallelresources/events/ResourcePackHandle.java
+++ b/modules/src/main/java/parallelmc/parallelutils/modules/parallelresources/events/ResourcePackHandle.java
@@ -1,5 +1,6 @@
 package parallelmc.parallelutils.modules.parallelresources.events;
 
+import net.kyori.adventure.text.Component;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -7,33 +8,61 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerChangedWorldEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerResourcePackStatusEvent;
 import org.jetbrains.annotations.NotNull;
 import parallelmc.parallelutils.ParallelUtils;
 import parallelmc.parallelutils.modules.parallelresources.ParallelResources;
 
+import java.util.logging.Level;
+
 public class ResourcePackHandle implements Listener {
 
-	private final ParallelUtils puPlugin;
-	private final ParallelResources resources;
 
-	public ResourcePackHandle(ParallelUtils puPlugin, ParallelResources resources) {
+
+	private ParallelUtils puPlugin;
+	private ParallelResources resources;
+
+	private Component warningMessage;
+
+	public ResourcePackHandle(ParallelUtils puPlugin, ParallelResources resources, Component warningMessage) {
 		this.puPlugin = puPlugin;
 		this.resources = resources;
+		this.warningMessage = warningMessage;
 	}
 
 	@EventHandler(priority = EventPriority.HIGHEST)
 	public void onPlayerJoin(PlayerJoinEvent event) {
 		Player player = event.getPlayer();
 
-		applyPack(player);
+		if (!applyPack(player)) {
+			ParallelUtils.log(Level.SEVERE, "UNABLE TO APPLY RESOURCE PACK!");
+		}
 	}
 
 	@EventHandler(priority = EventPriority.HIGHEST)
 	public void onWorldChange(PlayerChangedWorldEvent event) {
 		Player player = event.getPlayer();
 
-		applyPack(player);
+		if (!applyPack(player)) {
+			ParallelUtils.log(Level.SEVERE, "UNABLE TO APPLY RESOURCE PACK!");
+		}
+	}
 
+	@EventHandler(priority = EventPriority.HIGHEST)
+	public void onResourcePackStatus(PlayerResourcePackStatusEvent event) {
+		PlayerResourcePackStatusEvent.Status status = event.getStatus();
+
+		switch (status) {
+			case DECLINED -> {
+				ParallelUtils.log(Level.WARNING, "Event " + status.toString() + " occurred! Declining join");
+				event.getPlayer().kick(warningMessage);
+			}
+			case FAILED_DOWNLOAD -> {
+				ParallelUtils.log(Level.WARNING, "Event " + status.toString() + " occurred! Declining join");
+				event.getPlayer().kick(warningMessage.append(
+						Component.text("If you believe this was an error, please contact staff on Discord.")));
+			}
+		}
 	}
 
 	public boolean applyPack(@NotNull Player player) {
@@ -41,8 +70,24 @@ public class ResourcePackHandle implements Listener {
 
 		String worldName = world.getName();
 
+		String resourceUrl = resources.getResourceUrl(worldName);
 
+		byte[] hash = resources.getHash(worldName);
+
+		if (hash == null) {
+			hash = resources.getHash("base");
+		}
+
+		player.setResourcePack(resourceUrl, hash, warningMessage, true);
 
 		return true;
+	}
+
+	public void disable() {
+		PlayerJoinEvent.getHandlerList().unregister(this);
+		PlayerChangedWorldEvent.getHandlerList().unregister(this);
+		puPlugin = null;
+		resources = null;
+		warningMessage = null;
 	}
 }

--- a/modules/src/main/java/parallelmc/parallelutils/modules/parallelresources/events/ResourcePackHandle.java
+++ b/modules/src/main/java/parallelmc/parallelutils/modules/parallelresources/events/ResourcePackHandle.java
@@ -1,0 +1,46 @@
+package parallelmc.parallelutils.modules.parallelresources.events;
+
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerChangedWorldEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.jetbrains.annotations.NotNull;
+import parallelmc.parallelutils.ParallelUtils;
+import parallelmc.parallelutils.modules.parallelresources.ParallelResources;
+
+public class ResourcePackHandle implements Listener {
+
+	private final ParallelUtils puPlugin;
+	private final ParallelResources resources;
+
+	public ResourcePackHandle(ParallelUtils puPlugin, ParallelResources resources) {
+		this.puPlugin = puPlugin;
+		this.resources = resources;
+	}
+
+	@EventHandler(priority = EventPriority.HIGHEST)
+	public void onPlayerJoin(PlayerJoinEvent event) {
+		Player player = event.getPlayer();
+
+		applyPack(player);
+	}
+
+	@EventHandler(priority = EventPriority.HIGHEST)
+	public void onWorldChange(PlayerChangedWorldEvent event) {
+		Player player = event.getPlayer();
+
+		applyPack(player);
+
+	}
+
+	public boolean applyPack(@NotNull Player player) {
+		World world = player.getWorld();
+
+		String worldName = world.getName();
+
+		return true;
+	}
+}

--- a/modules/src/main/java/parallelmc/parallelutils/modules/parallelresources/events/ResourcePackHandle.java
+++ b/modules/src/main/java/parallelmc/parallelutils/modules/parallelresources/events/ResourcePackHandle.java
@@ -41,6 +41,8 @@ public class ResourcePackHandle implements Listener {
 
 		String worldName = world.getName();
 
+
+
 		return true;
 	}
 }

--- a/modules/src/main/java/parallelmc/parallelutils/modules/parallelresources/events/ResourcePackHandle.java
+++ b/modules/src/main/java/parallelmc/parallelutils/modules/parallelresources/events/ResourcePackHandle.java
@@ -70,13 +70,15 @@ public class ResourcePackHandle implements Listener {
 
 		String worldName = world.getName();
 
-		String resourceUrl = resources.getResourceUrl(worldName);
-
 		byte[] hash = resources.getHash(worldName);
 
 		if (hash == null) {
+			ParallelUtils.log(Level.INFO, "Tried to get pack for invalid world. Defaulting to base");
+			worldName = "base";
 			hash = resources.getHash("base");
 		}
+
+		String resourceUrl = resources.getResourceUrl(worldName);
 
 		player.setResourcePack(resourceUrl, hash, warningMessage, true);
 


### PR DESCRIPTION
This is kind of a mess so I want someone to look through it a bit. It does work, but it's just weird code.
To use:
- Start the module once to generate base files
- Put a resource pack (that has NOT been run through packsquash) in `resources/base.zip`
- Create directories for each world, following resource pack structure, with files to add or replace. Support for removing files is currently not implemented
  - If you have a world named `test`, create a folder `resources/test/` which contains the directory structure needed.
- Modify the `resources/parallelresources.yml` file as needed
  - To add HTTPS support, you must also add an entry for `https_keystore`, which points to the keystore file and `https_keystore_pass` for the password of the keystore.
- If you want to use packsquash, add a `packsquash` binary and a `packsquash.toml`  to `resources/`. This config file should not include source and destination. 