### PR TITLE
fix many database related issues, add chestshop debug command

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -90,6 +90,11 @@ bukkit {
             usage = '/town'
             permissionMessage = 'You do not have permission'
         }
+        chestshop {
+            description = 'Base command for all ChestShop debug commands'
+            usage = '/chestshop'
+            permissionMessage = 'You do not have permission'
+        }
         depositexp {
             description = 'Deposit exp into the player\' s ender chest '
             usage = '/depositexp <amount | all>'
@@ -461,6 +466,10 @@ bukkit {
         }
         'parallelutils.notify.antislur' {
             description = 'Be notified of swearing'
+        }
+        'parallelutils.chestshop.debug' {
+            description = 'Gives access to ChestShop debug commands'
+            setDefault('FALSE')
         }
     }
 }

--- a/modules/src/main/java/parallelmc/parallelutils/modules/bitsandbobs/minimodules/togglepvp/TogglePvpManager.java
+++ b/modules/src/main/java/parallelmc/parallelutils/modules/bitsandbobs/minimodules/togglepvp/TogglePvpManager.java
@@ -24,7 +24,10 @@ public class TogglePvpManager {
                     create table if not exists TogglePvp
                     (
                         UUID        varchar(36) not null,
-                        Pvp         tinyint     not null
+                        Pvp         tinyint     not null,
+                        constraint TogglePvp_UUID_uindex
+                            unique (UUID),
+                        PRIMARY KEY (UUID)
                     );""");
             conn.commit();
             statement.close();

--- a/modules/src/main/java/parallelmc/parallelutils/modules/chestshops/commands/ChestShopCommand.java
+++ b/modules/src/main/java/parallelmc/parallelutils/modules/chestshops/commands/ChestShopCommand.java
@@ -1,0 +1,43 @@
+package parallelmc.parallelutils.modules.chestshops.commands;
+
+import org.bukkit.command.Command;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public abstract class ChestShopCommand {
+
+    public String name;
+    public String helpText;
+
+    /**
+     * Creates a new ChestShopCommand with the specified name and help text
+     *
+     * @param name       The name of the command
+     * @param helpText   The helpText of the command
+     */
+    public ChestShopCommand(String name, String helpText) {
+        this.name = name;
+        this.helpText = helpText;
+    }
+
+    /**
+     * Execute the command given the params from the Bukkit {@code onCommand} method
+     *
+     * @param player  The Player that is executing this Command
+     * @param command The Bukkit {@code Command} object
+     * @param args    The arguments for this command
+     * @return Returns true if the command executed successfully
+     */
+    public abstract boolean execute(@NotNull Player player, @NotNull Command command, @NotNull String[] args);
+
+    /**
+     * Retrieve the tab complete array associated with the given command and arguments
+     *
+     * @param player The sender of this command
+     * @param args   The arguments associated with the command
+     * @return The List associated with the given command, sender, and arguments
+     */
+    public abstract List<String> getTabComplete(@NotNull Player player, @NotNull String[] args);
+}

--- a/modules/src/main/java/parallelmc/parallelutils/modules/chestshops/commands/ChestShopCommands.java
+++ b/modules/src/main/java/parallelmc/parallelutils/modules/chestshops/commands/ChestShopCommands.java
@@ -1,0 +1,98 @@
+package parallelmc.parallelutils.modules.chestshops.commands;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import parallelmc.parallelutils.modules.parallelchat.ParallelChat;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class ChestShopCommands implements CommandExecutor, TabCompleter {
+    private final HashMap<String, ChestShopCommand> commandMap;
+
+    public ChestShopCommands() {
+        commandMap = new HashMap<>();
+    }
+
+    /**
+     * Adds a new command to the commandmap
+     *
+     * @param name    The name of the command
+     * @param command The command to be run when the name is called
+     * @return Returns true when the command was added successfully, false if the command already exists.
+     */
+    public boolean addCommand(String name, ChestShopCommand command) {
+        if (commandMap.containsKey(name.toLowerCase().strip())) {
+            return false;
+        }
+
+        commandMap.put(name.toLowerCase().strip(), command);
+
+        return true;
+    }
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        // only players can run chestshop commands
+        if (sender instanceof Player player) {
+            if (!player.hasPermission("parallelutils.chestshop.debug")) {
+                return true;
+            }
+            if (command.getName().equalsIgnoreCase("chestshop")) {
+                // If no command was specified, toggle the player's active chatroom
+                if (args.length == 0) {
+                    ParallelChat.sendParallelMessageTo(player, "Please select a sub-command.");
+                } else {
+                    ChestShopCommand executingCommand = commandMap.get(args[0]);
+
+                    if (executingCommand != null) {
+                        executingCommand.execute(player, command, args);
+                    } else {
+                        ParallelChat.sendParallelMessageTo(player, "Unknown chestshop subcommand.");
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+    @Override
+    @Nullable
+    public List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String alias, @NotNull String[] args) {
+        ArrayList<String> list = new ArrayList<>();
+
+        if (sender instanceof Player player) {
+            // Show ChestShop commands
+
+            String lowerName = command.getName().toLowerCase().strip();
+
+            if ((lowerName.equals("chestshop")) && args.length == 1) {
+                // List every sub-command
+                list.addAll(commandMap.keySet());
+            } else {
+                if (commandMap.containsKey(args[0].toLowerCase().strip())) {
+                    return commandMap.get(args[0].toLowerCase().strip()).getTabComplete(player, args);
+                }
+            }
+        }
+        return list;
+    }
+
+    /**
+     * Return a deep copy of the command map. Modifying the returned map will not modify the commands
+     *
+     * @return A deep copy of the command map
+     */
+    public Map<String, ChestShopCommand> getCommands() {
+        return commandMap.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+}

--- a/modules/src/main/java/parallelmc/parallelutils/modules/chestshops/commands/ChestShopDebug.java
+++ b/modules/src/main/java/parallelmc/parallelutils/modules/chestshops/commands/ChestShopDebug.java
@@ -1,0 +1,68 @@
+package parallelmc.parallelutils.modules.chestshops.commands;
+
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.block.Block;
+import org.bukkit.block.Sign;
+import org.bukkit.command.Command;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import parallelmc.parallelutils.modules.chestshops.ChestShops;
+import parallelmc.parallelutils.modules.chestshops.Shop;
+import parallelmc.parallelutils.modules.parallelchat.ParallelChat;
+import net.kyori.adventure.text.Component;
+
+import java.util.List;
+
+public class ChestShopDebug extends ChestShopCommand {
+    private final String USAGE = "/chestshop debug";
+
+    public ChestShopDebug() { super("debug", "Prints debug info for the ChestShop you are looking at."); }
+
+    @Override
+    public boolean execute(@NotNull Player player, @NotNull Command command, @NotNull String[] args) {
+        if (args.length != 1) {
+            player.sendMessage(USAGE);
+            return false;
+        }
+
+        Block target = player.getTargetBlock(null, 6);
+        if (target instanceof Sign sign) {
+            List<Shop> shops = ChestShops.get().getAllShopsFromSignPos(sign.getLocation());
+            if (shops.isEmpty()) {
+                ParallelChat.sendParallelMessageTo(player, "No ChestShop data found at this location! This sign is safe to delete.");
+                return true;
+            }
+            for (Shop shop : shops) {
+                OfflinePlayer owner = Bukkit.getOfflinePlayer(shop.owner());
+
+                Component text = Component.text("----------------------\n", NamedTextColor.RED)
+                        .append(Component.text("ChestShop Debug Info:\n", NamedTextColor.YELLOW))
+                        .append(Component.text("----------------------\n", NamedTextColor.RED))
+                        .append(Component.text("Shop ID: " + shop.id().toString(), NamedTextColor.AQUA)).append(Component.newline())
+                        .append(Component.text("Owner:" + owner.getName(), NamedTextColor.AQUA)).append(Component.newline())
+                        .append(Component.text(String.format("Chest Position: %d %d %d", shop.chestPos().getBlockX(), shop.chestPos().getBlockY(), shop.chestPos().getBlockZ()), NamedTextColor.AQUA)).append(Component.newline())
+                        .append(Component.text(String.format("Sign Position: %d %d %d", shop.signPos().getBlockX(), shop.signPos().getBlockY(), shop.signPos().getBlockZ()), NamedTextColor.AQUA)).append(Component.newline())
+                        .append(Component.text("Sold Item: " + shop.item(), NamedTextColor.AQUA)).append(Component.newline())
+                        .append(Component.text("Buy Amount: " + shop.buyAmt() + " diamonds", NamedTextColor.AQUA)).append(Component.newline())
+                        .append(Component.text("Sell Amount: " + shop.sellAmt() + " items", NamedTextColor.AQUA)).append(Component.newline());
+                player.sendMessage(text);
+            }
+            if (shops.size() > 1) {
+                player.sendMessage(Component.text("WARNING: Multiple shops found at this location!", NamedTextColor.RED, TextDecoration.BOLD));
+            }
+
+        }
+        else {
+            ParallelChat.sendParallelMessageTo(player, "Please look at a ChestShop sign and run the command again.");
+        }
+        return true;
+    }
+
+    @Override
+    public List<String> getTabComplete(@NotNull Player player, @NotNull String[] args) {
+        return null;
+    }
+}

--- a/modules/src/main/java/parallelmc/parallelutils/modules/parallelchat/ParallelChat.java
+++ b/modules/src/main/java/parallelmc/parallelutils/modules/parallelchat/ParallelChat.java
@@ -144,7 +144,10 @@ public class ParallelChat extends ParallelModule {
                         UUID        varchar(36) not null,
                         SocSpy      tinyint     not null,
                         CmdSpy      tinyint     not null,
-                        ChatRoomSpy tinyint     not null
+                        ChatRoomSpy tinyint     not null,
+                        constraint SocialSpy_UUID_uindex
+                            unique (UUID),
+                        PRIMARY KEY (UUID)
                     );""");
             conn.commit();
             statement.close();
@@ -305,15 +308,17 @@ public class ParallelChat extends ParallelModule {
         // save spy data across shutdowns
         try (Connection conn = puPlugin.getDbConn()) {
             if (conn == null) throw new SQLException("Unable to establish connection!");
-            PreparedStatement statement = conn.prepareStatement("INSERT INTO SocialSpy (UUID, SocSpy, CmdSpy) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE SocSpy = ?, CmdSpy = ?");
+            PreparedStatement statement = conn.prepareStatement("INSERT INTO SocialSpy (UUID, SocSpy, CmdSpy, ChatRoomSpy) VALUES (?, ?, ?, ?) ON DUPLICATE KEY UPDATE SocSpy = ?, CmdSpy = ?, ChatRoomSpy = ?");
             statement.setQueryTimeout(30);
             this.socialSpyUsers.forEach((u, o) -> {
                 try {
                     statement.setString(1, u.toString());
                     statement.setBoolean(2, o.isSocialSpy());
                     statement.setBoolean(3, o.isCmdSpy());
-                    statement.setBoolean(4, o.isSocialSpy());
-                    statement.setBoolean(5, o.isCmdSpy());
+                    statement.setBoolean(4, o.isChatRoomSpy());
+                    statement.setBoolean(5, o.isSocialSpy());
+                    statement.setBoolean(6, o.isCmdSpy());
+                    statement.setBoolean(7, o.isChatRoomSpy());
                     statement.addBatch();
                 } catch (SQLException e) {
                     e.printStackTrace();


### PR DESCRIPTION
This PR fixes many issues related to the database, and adds a /chestshop debug command to print information into the chat about a ChestShop that the player is looking at. It will warn the player if multiple ChestShops are registered at the current location.

This PR also fixes an issue where removed ChestShops would not be removed on the database, resulting in stale entries. The PR makes it so that when the server shuts down, entries older than 15 minutes after data entry (aka any entries that did not get updated by the ON UPDATE CURRENT_TIMESTAMP clause) will be removed from the database.

Other tables had duplication issues as well due to the PRIMARY and UNIQUE keys not existing, which have already been fixed on the database side, and should function normally now without any changes to the code.